### PR TITLE
Added path option on make-socket

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [io.socket/socket.io-client "0.8.3"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.apache.logging.log4j/log4j-core "2.7"]

--- a/src/clj_socketio_client/core.clj
+++ b/src/clj_socketio_client/core.clj
@@ -38,10 +38,12 @@
   (.disconnect socket))
 
 (defn make-socket
-  "Make a new socket.  event-map is a map of event names (strings) to Listener instances."
-  [url event-map]
+  "Make a new socket.  event-map is a map of event names (strings) to Listener instances. path will be used as underlying IO.Options.path"
+  ([url path event-map]
   (let [connect-promise (promise)
-        socket (IO/socket url)
+        option (new io.socket.client.IO$Options)
+        set-path (set! (.-path option) path)
+        socket (IO/socket url option)
         effective-event-map (merge default-event-map
                                    {Socket/EVENT_CONNECT (fn [& args]
                                                            (debug (format "SocketIO client: Connected to %s" url))
@@ -54,6 +56,8 @@
     @connect-promise
     socket
     ))
+
+  ([url event-map] (make-socket url nil event-map)))
 
 (defn- make-args 
   [msg hash]


### PR DESCRIPTION
Without setting additional path options on IO.Options, I am getting "error xhr poll" for some socket.io source with additional path.  