### PR TITLE
Socket options set by a map as a param in make-socket

### DIFF
--- a/src/clj_socketio_client/core.clj
+++ b/src/clj_socketio_client/core.clj
@@ -37,35 +37,51 @@
   [socket]
   (.disconnect socket))
 
+(defn opt-fn [opt-key]
+  (cond
+    (= :path opt-key) (fn [io-options val]
+                        (set! (.-path io-options) val))
+    (= :transports opt-key) (fn [io-options val]
+                              (set! (.-transports io-options) (into-array val)))))
+
+(defn set-io-options [io-options opts]
+  "Sets the option vals on an IO$Options obj.
+  opts should be a map of option keys and fns that take two params
+  an options key (the name of the property) and the value of the property"
+  (doall
+    (map (fn [[k val]]
+           (let [opt-fn (opt-fn k)]
+             (opt-fn io-options val))) opts)))
+
 (defn make-socket
   "Make a new socket.  event-map is a map of event names (strings) to Listener instances. path will be used as underlying IO.Options.path"
-  ([url path event-map]
-  (let [connect-promise (promise)
-        option (new io.socket.client.IO$Options)
-        set-path (set! (.-path option) path)
-        socket (IO/socket url option)
-        effective-event-map (merge default-event-map
-                                   {Socket/EVENT_CONNECT (fn [& args]
-                                                           (debug (format "SocketIO client: Connected to %s" url))
-                                                           (deliver connect-promise true))}
-                                   event-map)]
-    (doseq [e (keys effective-event-map)]
-      (doto socket 
-        (.on e (->Listener (get effective-event-map e)))))
-    (connect! socket)
-    @connect-promise
-    socket
-    ))
+  ([url opts event-map]
+   (let [connect-promise (promise)
+         io-options (new io.socket.client.IO$Options)
+         set-opts (set-io-options io-options opts)
+         socket (IO/socket url io-options)
+         effective-event-map (merge default-event-map
+                                    {Socket/EVENT_CONNECT (fn [& args]
+                                                            (debug (format "SocketIO client: Connected to %s" url))
+                                                            (deliver connect-promise true))}
+                                    event-map)]
+     (doseq [e (keys effective-event-map)]
+       (doto socket
+         (.on e (->Listener (get effective-event-map e)))))
+     (connect! socket)
+     @connect-promise
+     socket
+     ))
 
   ([url event-map] (make-socket url nil event-map)))
 
-(defn- make-args 
+(defn- make-args
   [msg hash]
-  (cond (or (list? msg) (vector? msg) (seq? msg)) msg 
+  (cond (or (list? msg) (vector? msg) (seq? msg)) msg
         (map? msg) (let [json (JSONObject.)]
                      (debug (format "hash: %s" hash))
                      (debug (with-out-str (clojure.pprint/pprint msg)) )
-                     (when hash (.put json "hash" hash)) 
+                     (when hash (.put json "hash" hash))
                      (doseq [[k v] msg]
                        (.put json (name k) v))
                      [json])
@@ -85,32 +101,32 @@
   [url]
   {:pre [(not-empty url)]}
   (let [socket (make-socket url {"take" (fn [data & rest]
-                                      (let [data (cheshire.core/parse-string (.toString data) true)
-                                            output (:output data)
-                                            hash (:hash data)
-                                            p (get @pending-requests hash)]
-                                        (debug (with-out-str (clojure.pprint/pprint data)))
-                                        (debug (format "take callback; hash: %s; p: %s" hash p))
-                                        (when p
-                                          (swap! pending-requests dissoc hash)
-                                          (try (deliver p output)
-                                               (catch Exception e
-                                                 (error (.getMessage e)))))))})]
+                                          (let [data (cheshire.core/parse-string (.toString data) true)
+                                                output (:output data)
+                                                hash (:hash data)
+                                                p (get @pending-requests hash)]
+                                            (debug (with-out-str (clojure.pprint/pprint data)))
+                                            (debug (format "take callback; hash: %s; p: %s" hash p))
+                                            (when p
+                                              (swap! pending-requests dissoc hash)
+                                              (try (deliver p output)
+                                                   (catch Exception e
+                                                     (error (.getMessage e)))))))})]
     (emit! socket "join" (.id socket))
     socket))
 
 (defn pass-take
   [socket msg]
   {:pre [(map? msg) (.connected socket)]}
-  (let [p (promise) 
+  (let [p (promise)
         hash (.toString (java.util.UUID/randomUUID))
-        f (future 
+        f (future
             (Thread/sleep 60000)
             (when (not (realized? p))
               (swap! pending-requests dissoc hash)
               (deliver p :timeout)))]
     (swap! pending-requests assoc hash p)
-    (emit! socket "pass" 
+    (emit! socket "pass"
            (assoc msg :from (.id socket))
            hash)
     p))


### PR DESCRIPTION
Breaking change: Added the functionality to set any option on a socket. Currently, `path` and `transports` are implemented but is easily extendable by adding keys/fns to `opt-fn` 